### PR TITLE
chore: update backstage catalog entities

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,12 +1,9 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Location
 metadata:
-  name: tradiecore-review-documentation
-  description: Repository to store Tradiecore online review documentation
-  annotations:
-    github.com/project-slug: hipagesgroup/tradiecore-review-documentation
+  name: tradiecore-review-documentation-apps
+  description: Applications managed within the tradiecore-review-documentation monorepo.
 spec:
-  type: documentation
-  lifecycle: production
-  system: tradiecore
-  owner: job-management-experience
+  targets:
+    - ./catalog/*.yaml
+    - ./catalog/**/*.yaml

--- a/catalog/apps/tradiecore-review-documentation.yaml
+++ b/catalog/apps/tradiecore-review-documentation.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: tradiecore-review-documentation
+  title: "Tradiecore Review Documentation"
+  description: Repository to store Tradiecore online review documentation
+  annotations:
+    github.com/project-slug: hipagesgroup/tradiecore-review-documentation
+    github.com/team-slug: job-management-experience
+spec:
+  type: documentation
+  lifecycle: production
+  system: tradiecore
+  owner: job-management-experience


### PR DESCRIPTION
## Summary
- Convert `catalog-info.yaml` from a bare Component to a proper Location entity (structural convention)
- Move Component entity to `catalog/apps/tradiecore-review-documentation.yaml`
- Add `metadata.title` and `github.com/team-slug` annotation

## No functional changes
This is a documentation-only repo with no services, APIs, or infrastructure. The Component retains the same values (`type: documentation`, `system: tradiecore`, `owner: job-management-experience`) — it's just relocated to the standard catalog directory structure.

## Test plan
- [ ] Verify entity still appears in Backyard after merge at https://backyard.k8s.hipages.com.au/catalog/default/Component/tradiecore-review-documentation