### PR TITLE
chore: update backstage catalog entities

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
   name: tradiecore-review-documentation
-  description: Applications managed within the tradiecore-review-documentation monorepo.
+  description: Catalog entities for tradiecore-review-documentation.
 spec:
   targets:
     - ./catalog/*.yaml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: tradiecore-review-documentation-apps
+  name: tradiecore-review-documentation
   description: Applications managed within the tradiecore-review-documentation monorepo.
 spec:
   targets:

--- a/catalog/apps/tradiecore-review-documentation.yaml
+++ b/catalog/apps/tradiecore-review-documentation.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: hipagesgroup/tradiecore-review-documentation
     github.com/team-slug: job-management-experience
+  tags:
+    - repo
+    - documentation
 spec:
   type: documentation
   lifecycle: production


### PR DESCRIPTION
## Summary
- Fix `catalog-info.yaml` `metadata.name` from `tradiecore-review-documentation-apps` to `tradiecore-review-documentation` (must match repo name per convention)
- Add required `repo` tag to Component entity (root entity must have this tag for Backyard filtering)
- Add `documentation` tag to reflect component type

## Test plan
- [ ] Verify entity loads correctly in Backyard after merge
- [ ] Confirm `repo` tag appears in Backyard for filtering