### PR TITLE
chore: update backstage catalog entities

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,5 +5,4 @@ metadata:
   description: Catalog entities for tradiecore-review-documentation.
 spec:
   targets:
-    - ./catalog/*.yaml
     - ./catalog/**/*.yaml


### PR DESCRIPTION
## Summary
- Remove stale `./catalog/*.yaml` glob from `catalog-info.yaml` — no YAML files exist directly under `catalog/` (only under `catalog/apps/`), causing Backyard to throw `NotFoundError` on ingestion

## Test plan
- [ ] Verify Backyard successfully ingests the `tradiecore-review-documentation` component after merge