### PR TITLE
chore: update backstage catalog entities

### DIFF
--- a/catalog/apps/tradiecore-review-documentation.yaml
+++ b/catalog/apps/tradiecore-review-documentation.yaml
@@ -3,13 +3,23 @@ kind: Component
 metadata:
   name: tradiecore-review-documentation
   title: "Tradiecore Review Documentation"
-  description: Repository to store Tradiecore online review documentation
+  description: >-
+    End-user help documentation for the Tradiecore web experience, published at
+    help-web.hipages.com.au via GitHub Pages and linked from the Tradiecore web
+    app's help menu. MadCap Flare-generated; covers jobs, quotes, invoices,
+    customers, scheduling, and settings.
   annotations:
     github.com/project-slug: hipagesgroup/tradiecore-review-documentation
     github.com/team-slug: job-management-experience
+    backstage.io/techdocs-entity: system:default/tradiecore
   tags:
     - repo
     - documentation
+    - madcap-flare
+  links:
+    - url: https://help-web.hipages.com.au
+      title: Published Documentation Site
+      icon: docs
 spec:
   type: documentation
   lifecycle: production


### PR DESCRIPTION
## What

Backstage catalog audit fixes:

- **Component description**: replace the placeholder with one grounded in reality — this repo publishes the live Tradiecore web help site at help-web.hipages.com.au (CNAME in repo, GitHub Pages `status: built`, linked from `tradiecore-web` `app/components/navigation-pane/accountMenuSections.ts`).
- **TechDocs annotation**: add `backstage.io/techdocs-entity: system:default/tradiecore`, matching the sibling docs repos (the `tradiecore` System in `tradie-core` has `techdocs-ref`).
- **Links**: add the published site (https://help-web.hipages.com.au).
- **Tags**: add `madcap-flare`.

## Why

Part of the org-wide Backstage catalog audit — keeping catalog entities accurate and consistent across repos.

## Notes

The repo name says "review" but it serves the **live** help-web.hipages.com.au site linked from the Tradiecore web app's help menu — flagged as a naming question for job-management-experience rather than renamed.